### PR TITLE
Add basic CV and cover letter generator web app

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+__pycache__/
+*.pyc

--- a/README.md
+++ b/README.md
@@ -1,2 +1,26 @@
-# Codex_test
-Test of the Codex app of OpenAI
+# CV Generator
+
+This project is a simple web application that generates a CV and cover letter
+based on a user's existing resume and a job description. The application:
+
+* Extracts skills from an uploaded resume PDF.
+* Extracts required skills from a job description.
+* Asks the user about missing skills and optionally adds them.
+* Produces a basic CV and cover letter with a theme derived from the job description.
+
+## Running
+
+```bash
+pip install -r requirements.txt
+python app.py
+```
+
+Then open `http://localhost:5000` in your browser.
+
+## Testing
+
+Run the unit tests with:
+
+```bash
+pytest
+```

--- a/app.py
+++ b/app.py
@@ -1,0 +1,70 @@
+from flask import Flask, render_template, request, redirect, url_for, session
+from resume_parser import parse_resume
+from job_parser import parse_job_description
+from skills import extract_skills
+
+app = Flask(__name__)
+app.secret_key = "dev"  # In production, load this from an environment variable
+
+
+def choose_theme(job_text: str) -> str:
+    job_text = job_text.lower()
+    if "design" in job_text or "designer" in job_text:
+        return "design"
+    elif "engineer" in job_text or "developer" in job_text:
+        return "tech"
+    return "default"
+
+
+@app.route("/")
+def index():
+    return render_template("index.html")
+
+
+@app.route("/process", methods=["POST"])
+def process():
+    resume_file = request.files.get("resume")
+    job_description = request.form.get("job_description", "")
+    if not resume_file or not job_description:
+        return redirect(url_for("index"))
+
+    resume_skills = parse_resume(resume_file.stream)
+    job_skills = parse_job_description(job_description)
+    missing_skills = sorted(job_skills - resume_skills)
+
+    session["resume_skills"] = list(resume_skills)
+    session["job_skills"] = list(job_skills)
+    session["job_description"] = job_description
+    session["theme"] = choose_theme(job_description)
+
+    if missing_skills:
+        return render_template("missing_skills.html", missing_skills=missing_skills)
+
+    # If no missing skills, generate immediately
+    return redirect(url_for("generate"))
+
+
+@app.route("/generate", methods=["GET", "POST"])
+def generate():
+    resume_skills = set(session.get("resume_skills", []))
+    job_description = session.get("job_description", "")
+
+    if request.method == "POST":
+        added_skills = request.form.getlist("add_skill")
+        resume_skills.update(added_skills)
+        session["resume_skills"] = list(resume_skills)
+
+    theme = session.get("theme", "default")
+    job_skills = set(session.get("job_skills", []))
+
+    return render_template(
+        "result.html",
+        skills=sorted(resume_skills),
+        job_skills=sorted(job_skills),
+        job_description=job_description,
+        theme=theme,
+    )
+
+
+if __name__ == "__main__":
+    app.run(debug=True)

--- a/job_parser.py
+++ b/job_parser.py
@@ -1,0 +1,8 @@
+"""Functions for extracting information from job descriptions."""
+from typing import Set
+from skills import extract_skills
+
+
+def parse_job_description(text: str) -> Set[str]:
+    """Return the set of skills mentioned in a job description."""
+    return extract_skills(text)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,2 @@
+Flask
+PyPDF2

--- a/resume_parser.py
+++ b/resume_parser.py
@@ -1,0 +1,19 @@
+"""Functions for extracting information from resumes."""
+from typing import Set
+from PyPDF2 import PdfReader
+from skills import extract_skills
+
+
+def extract_text_from_pdf(file_stream) -> str:
+    """Extract raw text from a PDF file-like object."""
+    reader = PdfReader(file_stream)
+    text = ""
+    for page in reader.pages:
+        text += page.extract_text() or ""
+    return text
+
+
+def parse_resume(file_stream) -> Set[str]:
+    """Parse a resume PDF and return the set of skills found."""
+    text = extract_text_from_pdf(file_stream)
+    return extract_skills(text)

--- a/skills.py
+++ b/skills.py
@@ -1,0 +1,19 @@
+"""Utility functions for skill extraction."""
+from typing import Set, Iterable
+
+# A simple list of known skills. In a real application this could be
+# replaced with a more comprehensive database or a machine learning model.
+KNOWN_SKILLS = {
+    "python", "java", "javascript", "html", "css", "flask",
+    "django", "react", "sql", "machine learning", "data analysis",
+    "communication", "leadership", "project management", "git"
+}
+
+def extract_skills(text: str, known_skills: Iterable[str] = KNOWN_SKILLS) -> Set[str]:
+    """Return the set of skills found in *text*.
+
+    The function performs a simple case-insensitive substring search for each
+    item in ``known_skills``.
+    """
+    text_lower = text.lower()
+    return {skill for skill in known_skills if skill.lower() in text_lower}

--- a/static/default.css
+++ b/static/default.css
@@ -1,0 +1,4 @@
+/* Default theme */
+body {
+    background-color: #f9f9f9;
+}

--- a/static/design.css
+++ b/static/design.css
@@ -1,0 +1,7 @@
+/* Design theme */
+body {
+    background-color: #fff0f6;
+}
+h1 {
+    color: #c2185b;
+}

--- a/static/style.css
+++ b/static/style.css
@@ -1,0 +1,8 @@
+body {
+    font-family: Arial, sans-serif;
+    margin: 40px;
+}
+
+h1 {
+    color: #333;
+}

--- a/static/tech.css
+++ b/static/tech.css
@@ -1,0 +1,7 @@
+/* Tech theme */
+body {
+    background-color: #e6f0ff;
+}
+h1 {
+    color: #004a99;
+}

--- a/templates/index.html
+++ b/templates/index.html
@@ -1,0 +1,17 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <title>CV Generator</title>
+    <link rel="stylesheet" href="{{ url_for('static', filename='style.css') }}">
+</head>
+<body>
+    <h1>CV and Cover Letter Generator</h1>
+    <form action="{{ url_for('process') }}" method="post" enctype="multipart/form-data">
+        <label>Resume (PDF): <input type="file" name="resume" required></label><br><br>
+        <label>Job Description:</label><br>
+        <textarea name="job_description" rows="10" cols="60" required></textarea><br><br>
+        <button type="submit">Analyze</button>
+    </form>
+</body>
+</html>

--- a/templates/missing_skills.html
+++ b/templates/missing_skills.html
@@ -1,0 +1,19 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <title>Confirm Skills</title>
+    <link rel="stylesheet" href="{{ url_for('static', filename='style.css') }}">
+</head>
+<body>
+    <h1>Missing Skills</h1>
+    <p>The job description mentions skills that weren't found in your resume. Do you have any of these?</p>
+    <form action="{{ url_for('generate') }}" method="post">
+        {% for skill in missing_skills %}
+        <label><input type="checkbox" name="add_skill" value="{{ skill }}"> {{ skill }}</label><br>
+        {% endfor %}
+        <br>
+        <button type="submit">Generate CV and Cover Letter</button>
+    </form>
+</body>
+</html>

--- a/templates/result.html
+++ b/templates/result.html
@@ -1,0 +1,23 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <title>Generated Documents</title>
+    <link rel="stylesheet" href="{{ url_for('static', filename='style.css') }}">
+    <link rel="stylesheet" href="{{ url_for('static', filename=theme + '.css') }}">
+</head>
+<body>
+    <h1>Your CV</h1>
+    <h2>Skills</h2>
+    <ul>
+    {% for skill in skills %}
+        <li>{{ skill }}</li>
+    {% endfor %}
+    </ul>
+
+    <h1>Cover Letter</h1>
+    <p>Dear Hiring Manager,</p>
+    <p>I am excited to apply for this position. My experience with {{ skills|join(', ') }} makes me a strong candidate. I am eager to contribute these skills to your team.</p>
+    <p>Sincerely,<br>Your Name</p>
+</body>
+</html>

--- a/tests/test_skills.py
+++ b/tests/test_skills.py
@@ -1,0 +1,8 @@
+from skills import extract_skills
+
+def test_extract_skills_basic():
+    text = "Experienced in Python and project management."
+    skills = extract_skills(text)
+    assert "python" in skills
+    assert "project management" in skills
+    assert "java" not in skills


### PR DESCRIPTION
## Summary
- Build a Flask app that analyzes resume PDFs and job descriptions to create a themed CV and cover letter.
- Added simple skill extraction utilities and templates for uploading resumes, confirming missing skills, and viewing results.
- Introduced basic tests and requirements.

## Testing
- `python -m pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b2c53e46508326a2d095ebac0b842e